### PR TITLE
feat: Implementar creación de Pacientes (POST), relaciones y arreglos de configuración

### DIFF
--- a/apps/backend/src/main/java/com/example/authbackend/controller/PatientController.java
+++ b/apps/backend/src/main/java/com/example/authbackend/controller/PatientController.java
@@ -3,9 +3,8 @@ package com.example.authbackend.controller;
 import com.example.authbackend.dto.PatientDTO;
 import com.example.authbackend.service.PatientService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -19,5 +18,10 @@ public class PatientController {
     @GetMapping
     public List<PatientDTO> list() {
         return patientService.getAllPatients();
+    }
+
+    @PostMapping
+    public ResponseEntity<PatientDTO> createPatient(@RequestBody PatientDTO patientDTO) {
+        return ResponseEntity.ok(patientService.createPatient(patientDTO));
     }
 }

--- a/apps/backend/src/main/java/com/example/authbackend/dto/PatientDTO.java
+++ b/apps/backend/src/main/java/com/example/authbackend/dto/PatientDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -15,6 +17,11 @@ public class PatientDTO {
     private String firstName;
     private String lastName;
     private String occupation;
+    private LocalDate birthDate;
+    private String maritalStatus;
+    private String sex;
     private Boolean active;
-    // No incluimos 'professional' ni listas pesadas para que sea rápido
+
+    // Para relacionarlo con el médico (Foreign Key)
+    private Integer professionalId;
 }

--- a/apps/backend/src/main/java/com/example/authbackend/model/Professional.java
+++ b/apps/backend/src/main/java/com/example/authbackend/model/Professional.java
@@ -6,10 +6,10 @@ import java.util.List;
 
 @Entity
 @Table(name = "professionals")
-@Getter // Genera getters para todos los campos
-@Setter // Genera setters para todos los campos
-@NoArgsConstructor // Genera el constructor vacío (Obligatorio para JPA)
-@AllArgsConstructor // Genera un constructor con todos los argumentos (Útil para tests)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder // Patrón Builder (Opcional, pero muy pro para crear objetos)
 public class Professional {
 

--- a/apps/backend/src/main/java/com/example/authbackend/service/PatientService.java
+++ b/apps/backend/src/main/java/com/example/authbackend/service/PatientService.java
@@ -2,7 +2,9 @@ package com.example.authbackend.service;
 
 import com.example.authbackend.dto.PatientDTO;
 import com.example.authbackend.model.Patient;
+import com.example.authbackend.model.Professional; // Asegúrate de tener este modelo
 import com.example.authbackend.repository.PatientRepository;
+import com.example.authbackend.repository.ProfessionalRepository; // Necesitas este repo
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,18 +12,44 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
-@RequiredArgsConstructor // Inyecta el repositorio automáticamente
+@RequiredArgsConstructor
 public class PatientService {
 
     private final PatientRepository patientRepository;
+    private final ProfessionalRepository professionalRepository;
 
+    // MÉTODO PARA OBTENER TODOS (GET) ---
     public List<PatientDTO> getAllPatients() {
         return patientRepository.findAll().stream()
                 .map(this::convertToDTO)
                 .collect(Collectors.toList());
     }
 
-    // Método helper para transformar de Entity a DTO
+    //  MÉTODO PARA CREAR (POST) ---
+    public PatientDTO createPatient(PatientDTO dto) {
+
+        Professional professional = professionalRepository.findById(Long.valueOf(dto.getProfessionalId()))
+                .orElseThrow(() -> new RuntimeException("Professional not found with ID: " + dto.getProfessionalId()));
+
+        // Mapear DTO a Entidad
+        Patient patient = new Patient();
+        patient.setFirstName(dto.getFirstName());
+        patient.setLastName(dto.getLastName());
+        patient.setInternalCode(dto.getInternalCode());
+        patient.setOccupation(dto.getOccupation());
+        patient.setBirthDate(dto.getBirthDate());
+        patient.setSex(dto.getSex());
+        patient.setMaritalStatus(dto.getMaritalStatus());
+        patient.setActive(true); // Por defecto activo
+        // Asignar la relación
+        patient.setProfessional(professional);
+
+        // Guardar y devolver convertido
+        Patient savedPatient = patientRepository.save(patient);
+        return convertToDTO(savedPatient);
+    }
+
+    // --- MÉTODOS AUXILIARES ---
     private PatientDTO convertToDTO(Patient patient) {
         return PatientDTO.builder()
                 .id(patient.getId())
@@ -30,6 +58,9 @@ public class PatientService {
                 .lastName(patient.getLastName())
                 .occupation(patient.getOccupation())
                 .active(patient.getActive())
+                .birthDate(patient.getBirthDate())
+                // Extraemos solo el ID para enviarlo al frontend
+                .professionalId(patient.getProfessional() != null ? patient.getProfessional().getId() : null)
                 .build();
     }
 }


### PR DESCRIPTION
📝 Descripción
Este PR habilita la funcionalidad completa para crear pacientes asignados a un profesional y soluciona los problemas de arranque del servidor y conexión con el Frontend (CORS).

🛠️ Cambios Realizados
Corrección de Arranque:

Eliminada la palabra abstract de AuthService para permitir la inyección de dependencias.

Solucionado conflicto de puertos (Docker vs IntelliJ) en el puerto 3000.

Gestión de Pacientes (Backend):

Implementado endpoint POST /api/patients.

Actualizado PatientDTO con campos obligatorios (birthDate, sex, professionalId).

Implementada lógica para validar que el Professional existe antes de asignar el paciente.

Configuración & Seguridad:

CORS Global: Habilitados puertos 5173 (Dev), 5174 (Vite alternativo) y 4173 (Preview) para evitar bloqueos al Frontend.

🧪 Cómo probar (Para Frontend)
Hacer Login para obtener el Token.

Enviar una petición POST a http://localhost:3000/api/patients con este JSON:

JSON
{
  "firstName": "Laura",
  "lastName": "Prueba",
  "internalCode": "PAC-2026-001",
  "occupation": "Ingeniera",
  "active": true,
  "birthDate": "1990-05-20",
  "sex": "F",
  "maritalStatus": "Soltera",
  "professionalId": 1
}
✅ Checklist
[x] El servidor arranca sin errores en el puerto 3000.

[x] El Login devuelve Token correctamente.

[x] Se pueden listar pacientes (GET).

[x] Se pueden crear pacientes (POST) y se guardan en BD.