### PR TITLE
feat: Módulo de Registro y Consulta de Sesiones Clínicas

### DIFF
--- a/apps/backend/src/main/java/com/example/authbackend/config/SecurityConfig.java
+++ b/apps/backend/src/main/java/com/example/authbackend/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthFilter;
 
-    // INYECTAMOS TU CONFIGURACIÓN DESDE APPLICATION.PROPERTIES
+    // INYECTAMOS LA CONFIGURACIÓN DESDE APPLICATION.PROPERTIES
     // Si la propiedad no existe, usamos localhost:5173 por defecto para que no falle.
     @Value("${spring.web.cors.allowed-origins:http://localhost:5173}")
     private String allowedOrigins;

--- a/apps/backend/src/main/java/com/example/authbackend/controller/AuthController.java
+++ b/apps/backend/src/main/java/com/example/authbackend/controller/AuthController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.*;
 
 /**
  * Controlador para la gestión de autenticación y registro de profesionales.
- * Cumple con el requerimiento RF1 del sistema PSICAID.
  */
 @RestController
 @RequestMapping("/api/auth")

--- a/apps/backend/src/main/java/com/example/authbackend/controller/AuthController.java
+++ b/apps/backend/src/main/java/com/example/authbackend/controller/AuthController.java
@@ -12,11 +12,11 @@ import org.springframework.web.bind.annotation.*;
 
 /**
  * Controlador para la gestión de autenticación y registro de profesionales.
- * Cumple con el requerimiento RF1 del sistema PSICAID[cite: 34, 35].
+ * Cumple con el requerimiento RF1 del sistema PSICAID.
  */
 @RestController
 @RequestMapping("/api/auth")
-@RequiredArgsConstructor // Genera el constructor para la inyección de dependencias (Senior Practice)
+@RequiredArgsConstructor // Genera el constructor para la inyección de dependencias
 public class AuthController {
 
     private final AuthService authService;

--- a/apps/backend/src/main/java/com/example/authbackend/controller/PatientController.java
+++ b/apps/backend/src/main/java/com/example/authbackend/controller/PatientController.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 /**
  * Controlador para la gestión de pacientes.
- * Centraliza las operaciones del RF2 - Gestión de pacientes.
+ * Centraliza las operaciones de gestión de pacientes.
  */
 @RestController
 @RequestMapping("/api/patients")

--- a/apps/backend/src/main/java/com/example/authbackend/controller/PatientController.java
+++ b/apps/backend/src/main/java/com/example/authbackend/controller/PatientController.java
@@ -13,10 +13,10 @@ import java.util.List;
 
 /**
  * Controlador para la gestión de pacientes.
- * Centraliza las operaciones del RF2 - Gestión de pacientes[cite: 36, 37].
+ * Centraliza las operaciones del RF2 - Gestión de pacientes.
  */
 @RestController
-@RequestMapping("/api/patients") // Ruta limpia, estándar y profesional
+@RequestMapping("/api/patients")
 @RequiredArgsConstructor
 public class PatientController {
 
@@ -24,14 +24,14 @@ public class PatientController {
 
     @GetMapping
     public ResponseEntity<List<PatientDTO>> listPatients() {
-        // Obtenemos los pacientes asegurando el aislamiento de datos (RB-04)
+        // Obtenemos los pacientes asegurando el aislamiento de datos
         return ResponseEntity.ok(patientService.getPatientsByAuthenticatedProfessional());
     }
 
     @PostMapping
     public ResponseEntity<PatientDTO> createPatient(@Valid @RequestBody PatientDTO patientDTO) {
         // @Valid activa las restricciones del DTO.
-        // El paciente se asocia de forma única al profesional autenticado [cite: 82, 193]
+        // El paciente se asocia de forma única al profesional autenticado
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(patientService.createPatient(patientDTO));
     }

--- a/apps/backend/src/main/java/com/example/authbackend/controller/SessionController.java
+++ b/apps/backend/src/main/java/com/example/authbackend/controller/SessionController.java
@@ -1,0 +1,40 @@
+package com.example.authbackend.controller;
+
+import com.example.authbackend.dto.ClinicalSessionDTO;
+import com.example.authbackend.service.ClinicalSessionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+@RestController
+@RequestMapping("/api/patients") // La ruta base, siguiendo el estándar REST
+@RequiredArgsConstructor
+public class SessionController {
+
+    private final ClinicalSessionService sessionService;
+
+    /**
+     * Endpoint para obtener el historial clínico completo de un paciente.
+     */
+    @GetMapping("/{patientId}/sessions")
+    public ResponseEntity<List<ClinicalSessionDTO>> getPatientSessions(@PathVariable Long patientId) {
+        return ResponseEntity.ok(sessionService.getPatientSessions(patientId));
+    }
+
+    /**
+     * Endpoint para crear una nueva sesión clínica.
+     */
+    @PostMapping("/{patientId}/sessions")
+    public ResponseEntity<ClinicalSessionDTO> createSession(
+            @PathVariable Long patientId,
+            @Valid @RequestBody ClinicalSessionDTO sessionDTO) {
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(sessionService.createSession(patientId, sessionDTO));
+    }
+}

--- a/apps/backend/src/main/java/com/example/authbackend/dto/ClinicalSessionDTO.java
+++ b/apps/backend/src/main/java/com/example/authbackend/dto/ClinicalSessionDTO.java
@@ -26,7 +26,7 @@ public class ClinicalSessionDTO {
 
     private Integer duration; // En minutos
 
-    // --- Narrativa Clínica (Textos libres permitidos por HU2) ---
+    // --- Narrativa Clínica ---
     private String reasonConsultation;
     private String background;
     private String observations;

--- a/apps/backend/src/main/java/com/example/authbackend/dto/ClinicalSessionDTO.java
+++ b/apps/backend/src/main/java/com/example/authbackend/dto/ClinicalSessionDTO.java
@@ -1,0 +1,49 @@
+package com.example.authbackend.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClinicalSessionDTO {
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private Long id;
+
+    // --- Metadatos de la sesión ---
+    @NotNull(message = "La fecha y hora de la sesión es obligatoria")
+    private OffsetDateTime sessionDateTime;
+
+    private String sessionType; // Ej: Individual presencial
+
+    private Integer duration; // En minutos
+
+    // --- Narrativa Clínica (Textos libres permitidos por HU2) ---
+    private String reasonConsultation;
+    private String background;
+    private String observations;
+    private String hypothesis;
+    private String interventions;
+    private String clinicalEvolution;
+    private String therapeuticGoals;
+    private String diagnosticNotes;
+
+    // Relación de entrada
+    @NotNull(message = "El ID del paciente es obligatorio")
+    private Long patientId;
+
+    // --- Auditoría Automática (Solo lectura) ---
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private OffsetDateTime createdAt;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private OffsetDateTime updatedAt;
+}

--- a/apps/backend/src/main/java/com/example/authbackend/repository/ClinicalSessionRepository.java
+++ b/apps/backend/src/main/java/com/example/authbackend/repository/ClinicalSessionRepository.java
@@ -1,0 +1,11 @@
+package com.example.authbackend.repository;
+
+import com.example.authbackend.model.ClinicalSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ClinicalSessionRepository extends JpaRepository<ClinicalSession, Long> {
+
+    List<ClinicalSession> findByPatientIdOrderBySessionDateTimeDesc(Long patientId);
+}

--- a/apps/backend/src/main/java/com/example/authbackend/repository/PatientRepository.java
+++ b/apps/backend/src/main/java/com/example/authbackend/repository/PatientRepository.java
@@ -15,9 +15,8 @@ public interface PatientRepository extends JpaRepository<Patient, Long> {
 
     /**
      * Busca pacientes pertenecientes a un profesional específico.
-     * Esto garantiza el cumplimiento de la regla RB-04: Aislamiento total de datos[cite: 69].
-     * * @param professionalId ID del profesional autenticado.
-     * @return Lista de pacientes asociados a ese profesional[cite: 82, 193].
+     * Esto garantiza el cumplimiento del aislamiento total de datos.
+     * pasándole el  ID del profesional autenticado, devuelve lista de pacientes asociados a ese profesional.
      */
     List<Patient> findByProfessionalId(Long professionalId);
 }

--- a/apps/backend/src/main/java/com/example/authbackend/repository/ProfessionalRepository.java
+++ b/apps/backend/src/main/java/com/example/authbackend/repository/ProfessionalRepository.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 @Repository
 public interface ProfessionalRepository extends JpaRepository<Professional, Long> {
 
-    // Metodo mágico: Spring crea el SQL automáticamente al leer el nombre del metodo
     Optional<Professional> findByEmail(String email);
 
     // Para verificar si existe antes de registrar

--- a/apps/backend/src/main/java/com/example/authbackend/service/AuthService.java
+++ b/apps/backend/src/main/java/com/example/authbackend/service/AuthService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor // Inyección por constructor (Senior Practice)
+@RequiredArgsConstructor
 public class AuthService {
 
     private final ProfessionalRepository professionalRepository;
@@ -21,11 +21,10 @@ public class AuthService {
 
     /**
      * Registra un nuevo profesional en el sistema.
-     * Cumple con RF1 - Registro de profesionales.
      */
     @Transactional
     public AuthResponse register(RegisterRequest request) {
-        // 1. Verificamos si el email ya existe (RB-04 / Regla de negocio)
+        // 1. Verificamos si el email ya existe
         if (professionalRepository.existsByEmail(request.getEmail())) {
             throw new RuntimeException("El correo electrónico ya está registrado");
         }

--- a/apps/backend/src/main/java/com/example/authbackend/service/ClinicalSessionService.java
+++ b/apps/backend/src/main/java/com/example/authbackend/service/ClinicalSessionService.java
@@ -1,0 +1,112 @@
+package com.example.authbackend.service;
+
+import com.example.authbackend.dto.ClinicalSessionDTO;
+import com.example.authbackend.model.ClinicalSession;
+import com.example.authbackend.model.Patient;
+import com.example.authbackend.model.Professional;
+import com.example.authbackend.repository.ClinicalSessionRepository;
+import com.example.authbackend.repository.PatientRepository;
+import com.example.authbackend.repository.ProfessionalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ClinicalSessionService {
+
+    private final ClinicalSessionRepository sessionRepository;
+    private final PatientRepository patientRepository;
+    private final ProfessionalRepository professionalRepository;
+
+    /**
+     * Obtiene el profesional autenticado a través del JWT.
+     */
+    private Professional getAuthenticatedProfessional() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        return professionalRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("Profesional no encontrado"));
+    }
+
+    /**
+     * Obtiene y valida un paciente asegurando que pertenece al profesional.
+     */
+    private Patient getValidPatientForProfessional(Long patientId, Professional pro) {
+        Patient patient = patientRepository.findById(patientId)
+                .orElseThrow(() -> new RuntimeException("Paciente no encontrado"));
+
+        if (!patient.getProfessional().getId().equals(pro.getId())) {
+            throw new RuntimeException("Acceso denegado. Este paciente no te pertenece.");
+        }
+        return patient;
+    }
+
+    /**
+     * Crea una nueva sesión clínica.
+     */
+    @Transactional
+    public ClinicalSessionDTO createSession(Long patientId, ClinicalSessionDTO dto) {
+        Professional pro = getAuthenticatedProfessional();
+        Patient patient = getValidPatientForProfessional(patientId, pro);
+
+        // Convertimos el DTO a Entidad
+        ClinicalSession session = ClinicalSession.builder()
+                .sessionDateTime(dto.getSessionDateTime())
+                .sessionType(dto.getSessionType())
+                .duration(dto.getDuration())
+                .reasonConsultation(dto.getReasonConsultation())
+                .background(dto.getBackground())
+                .observations(dto.getObservations())
+                .hypothesis(dto.getHypothesis())
+                .interventions(dto.getInterventions())
+                .clinicalEvolution(dto.getClinicalEvolution())
+                .therapeuticGoals(dto.getTherapeuticGoals())
+                .diagnosticNotes(dto.getDiagnosticNotes())
+                .patient(patient)
+                .build();
+
+        ClinicalSession savedSession = sessionRepository.save(session);
+        return convertToDTO(savedSession);
+    }
+
+    /**
+     * Lista todas las sesiones de un paciente ordenadas cronológicamente.
+     */
+    @Transactional(readOnly = true)
+    public List<ClinicalSessionDTO> getPatientSessions(Long patientId) {
+        Professional pro = getAuthenticatedProfessional();
+        // Validamos la seguridad antes de buscar las sesiones
+        getValidPatientForProfessional(patientId, pro);
+
+        return sessionRepository.findByPatientIdOrderBySessionDateTimeDesc(patientId)
+                .stream()
+                .map(this::convertToDTO)
+                .collect(Collectors.toList());
+    }
+
+    // --- MAPEO DE ENTIDAD A DTO ---
+
+    private ClinicalSessionDTO convertToDTO(ClinicalSession session) {
+        return ClinicalSessionDTO.builder()
+                .id(session.getId())
+                .sessionDateTime(session.getSessionDateTime())
+                .sessionType(session.getSessionType())
+                .duration(session.getDuration())
+                .reasonConsultation(session.getReasonConsultation())
+                .background(session.getBackground())
+                .observations(session.getObservations())
+                .hypothesis(session.getHypothesis())
+                .interventions(session.getInterventions())
+                .clinicalEvolution(session.getClinicalEvolution())
+                .therapeuticGoals(session.getTherapeuticGoals())
+                .diagnosticNotes(session.getDiagnosticNotes())
+                .patientId(session.getPatient().getId())
+                .createdAt(session.getCreatedAt())
+                .updatedAt(session.getUpdatedAt())
+                .build();
+    }
+}

--- a/apps/backend/src/main/java/com/example/authbackend/service/JwtService.java
+++ b/apps/backend/src/main/java/com/example/authbackend/service/JwtService.java
@@ -16,7 +16,7 @@ import java.util.function.Function;
 public class JwtService {
     
     private static final String SECRET_KEY = "mySecretKey123456789012345678901234567890";
-    private static final long JWT_TOKEN_VALIDITY = 24 * 60 * 60 * 1000; // 24 hours
+    private static final long JWT_TOKEN_VALIDITY = 24 * 60 * 60 * 1000; // 24 horas
 
     private Key getSigningKey() {
         return Keys.hmacShaKeyFor(SECRET_KEY.getBytes());

--- a/apps/backend/src/main/java/com/example/authbackend/service/PatientService.java
+++ b/apps/backend/src/main/java/com/example/authbackend/service/PatientService.java
@@ -23,7 +23,6 @@ public class PatientService {
 
     /**
      * Método privado de utilidad para obtener al profesional que ha iniciado sesión.
-     * Garantiza el cumplimiento de RF6 - Control de acceso.
      */
     private Professional getAuthenticatedProfessional() {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
@@ -32,7 +31,7 @@ public class PatientService {
     }
 
     /**
-     * Lista solo los pacientes del profesional autenticado (RB-04).
+     * Lista solo los pacientes del profesional autenticado.
      */
     @Transactional(readOnly = true)
     public List<PatientDTO> getPatientsByAuthenticatedProfessional() {
@@ -44,7 +43,7 @@ public class PatientService {
     }
 
     /**
-     * Crea un paciente vinculado automáticamente al profesional logueado (HU1).
+     * Crea un paciente vinculado automáticamente al profesional logueado.
      */
     @Transactional
     public PatientDTO createPatient(PatientDTO patientDTO) {
@@ -78,7 +77,7 @@ public class PatientService {
         Patient patient = patientRepository.findById(patientId)
                 .orElseThrow(() -> new RuntimeException("Paciente no encontrado con ID: " + patientId));
 
-        // 3. VALIDACIÓN CRÍTICA (RB-04): Verificamos que el paciente sea de este profesional [cite: 68]
+        // 3. VALIDACIÓN: Verificamos que el paciente sea de este profesional
         if (!patient.getProfessional().getId().equals(pro.getId())) {
             // Lanzar una excepción aquí evita fugas de información.
             // En un caso real podríamos lanzar un 403 Forbidden.


### PR DESCRIPTION
## Descripción
He añadido la funcionalidad para que los psicólogos puedan registrar y consultar las notas de las sesiones de sus pacientes, preparando la base de datos para la integración con IA.

## Cambios principales
* Creados los endpoints `POST` y `GET` en la ruta `/api/patients/{patientId}/sessions`.
* Creada la entidad `ClinicalSession` (con campos `TEXT` para las notas largas) y su DTO con validaciones básicas.
* **Seguridad:** Añadida validación en el `ClinicalSessionService` para asegurar que un profesional solo pueda crear o ver sesiones de los pacientes que le pertenecen.
* El listado de sesiones ya devuelve los resultados ordenados de más reciente a más antigua.

## Para probar
1. Hacer un `POST` a `/api/patients/1/sessions` con datos de prueba y el token de un psicólogo. Debería devolver `201 Created`.
2. Hacer un `GET` a la misma ruta para ver el historial ordenado.
3. **Prueba de seguridad:** Intentar hacer las mismas peticiones usando el token de otro psicólogo distinto. Debería dar un error `400` de "Acceso denegado".