### PR TITLE
feat: Endpoint de validación de sesión y perfil de usuario (/api/auth/me)

### DIFF
--- a/apps/backend/src/main/java/com/example/authbackend/config/SecurityConfig.java
+++ b/apps/backend/src/main/java/com/example/authbackend/config/SecurityConfig.java
@@ -52,7 +52,8 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authz -> authz
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/auth/login", "/api/auth/register").permitAll()
+                        .requestMatchers("/api/auth/me").authenticated()
                         .requestMatchers("/api/health").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/apps/backend/src/main/java/com/example/authbackend/controller/AuthController.java
+++ b/apps/backend/src/main/java/com/example/authbackend/controller/AuthController.java
@@ -2,12 +2,16 @@ package com.example.authbackend.controller;
 
 import com.example.authbackend.dto.AuthResponse;
 import com.example.authbackend.dto.LoginRequest;
+import com.example.authbackend.dto.ProfessionalDTO;
 import com.example.authbackend.dto.RegisterRequest;
 import com.example.authbackend.service.AuthService;
+import com.example.authbackend.service.ProfessionalService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final ProfessionalService professionalService;
 
     @PostMapping("/register")
     public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
@@ -30,5 +35,19 @@ public class AuthController {
     public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
         // Para login, un 200 OK es el estándar
         return ResponseEntity.ok(authService.login(request));
+    }
+    /**
+     * Endpoint para validar el token actual y devolver los datos del psicólogo.
+     * Si el token expiró, el JwtFilter devolverá 401 antes de llegar aquí.
+     */
+    @GetMapping("/me")
+    public ResponseEntity<ProfessionalDTO> getCurrentUser() {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        ProfessionalDTO professionalDTO = professionalService.getProfessionalByEmail(email);
+
+        return ResponseEntity.ok(professionalDTO);
     }
 }

--- a/apps/backend/src/main/java/com/example/authbackend/service/AiIntegrationService.java
+++ b/apps/backend/src/main/java/com/example/authbackend/service/AiIntegrationService.java
@@ -4,6 +4,7 @@ import com.example.authbackend.dto.AiSummaryRequestDTO;
 import com.example.authbackend.dto.AiSummaryResponseDTO;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
@@ -15,8 +16,11 @@ public class AiIntegrationService {
     private final RestClient restClient;
 
     public AiIntegrationService(@Value("${ai.service.base-url}") String baseUrl) {
+        // Obligamos a Spring Boot a usar HTTP/1.1 básico
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         this.restClient = RestClient.builder()
                 .baseUrl(baseUrl)
+                .requestFactory(factory)
                 .build();
     }
 
@@ -25,40 +29,6 @@ public class AiIntegrationService {
      */
     public String getSessionSummary(Long psychologistId, String combinedNotes) {
 
-        // ==========================================
-        //  MOCK PARA DESARROLLO LOCAL AISLADO
-        // ==========================================
-        System.out.println("Enviando notas a IA (Mock): " + combinedNotes);
-
-        // Simulamos la respuesta exacta que nos daría el Python de Adrián
-        AiSummaryResponseDTO mockResponse = new AiSummaryResponseDTO();
-        mockResponse.setSessionId(999L);
-        mockResponse.setPsychologistId(psychologistId);
-
-        AiSummaryResponseDTO.SummaryData data = new AiSummaryResponseDTO.SummaryData();
-        data.setMainConcern("Ansiedad generalizada con episodios de insomnio (Generado por Mock)");
-
-        AiSummaryResponseDTO.ObservationData obs = new AiSummaryResponseDTO.ObservationData();
-        obs.setDuration("3 meses");
-        obs.setImprovement("Mejora con técnicas de respiración");
-        data.setObservations(obs);
-
-        data.setActionItems(List.of(
-                "Continuar con terapia cognitivo-conductual",
-                "Revisar higiene del sueño"
-        ));
-        data.setFollowUp("Revisar en 2 semanas");
-
-        mockResponse.setSummary(data);
-
-        // Pasamos el mock por nuestro formateador real
-        return formatSummaryToString(mockResponse);
-
-
-        // ==========================================
-        //  CÓDIGO REAL DE PRODUCCIÓN
-        // ==========================================
-        /*
         AiSummaryRequestDTO request = AiSummaryRequestDTO.builder()
                 .psychologistId(psychologistId)
                 .rawNotes(combinedNotes)
@@ -78,7 +48,7 @@ public class AiIntegrationService {
             System.err.println("Error al conectar con IA: " + e.getMessage());
             return "Error: No se pudo generar el resumen automático.";
         }
-        */
+
     }
 
     /**

--- a/apps/backend/src/main/java/com/example/authbackend/service/ProfessionalService.java
+++ b/apps/backend/src/main/java/com/example/authbackend/service/ProfessionalService.java
@@ -35,6 +35,22 @@ public class ProfessionalService {
         Professional updatedProfessional = professionalRepository.save(profesionalAuth);
         return convertToDTO(updatedProfessional);
     }
+    /**
+     * Obtiene los datos del profesional logueado.
+     */
+    public ProfessionalDTO getProfessionalByEmail(String email) {
+        Professional professional = professionalRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("Profesional no encontrado en la base de datos"));
+
+        // Convertimos la entidad al DTO que le enviaremos al frontend (¡sin la contraseña!)
+        return ProfessionalDTO.builder()
+                .id(professional.getId())
+                .firstName(professional.getFirstName())
+                .lastName(professional.getLastName())
+                .email(professional.getEmail())
+                // .role(professional.getRole()) // Si tienes roles, añádelo
+                .build();
+    }
 
     private ProfessionalDTO convertToDTO(Professional professional) {
         return ProfessionalDTO.builder()


### PR DESCRIPTION
Este PR introduce dos funcionalidades críticas para el núcleo de la aplicación:
1. **Gestión de Sesiones:** Soluciona la pérdida de sesión en el Frontend al recargar la página mediante un nuevo endpoint de validación.
2. **Motor de IA:** Completa y estabiliza la comunicación bidireccional (End-to-End) entre nuestro backend de Java (Spring Boot) y el microservicio de IA en Python (FastAPI) para la generación automática de resúmenes clínicos.

##  Cambios Realizados

### 1. Autenticación y Seguridad (/auth/me)
* **`AuthController.java` & `ProfessionalService.java`**: Añadido endpoint `GET /api/auth/me` que valida el JWT actual y devuelve un `ProfessionalDTO` seguro (sin contraseñas).
* **`SecurityConfig.java`**: Se corrigió el orden de interceptación de rutas. El endpoint `/me` ahora requiere autenticación estricta, previniendo accesos no autorizados.

### 2. Integración con Inteligencia Artificial (Python/FastAPI)
* **`AiIntegrationService.java`**: 
  * Se inyectó `SimpleClientHttpRequestFactory` en el `RestClient`. Esto fuerza el uso del estándar HTTP/1.1 puro, eliminando el error de "Unsupported upgrade request" (HTTP/2) al comunicarse con servidores Uvicorn en local.
* **`AiSummaryRequestDTO.java`**: Se añadieron anotaciones `@JsonProperty` para mapear correctamente nuestro `camelCase` (Java) al `snake_case` que espera el modelo Pydantic en Python (`psychologist_id`, `raw_notes`), resolviendo errores 400/422.
* **`application.properties`**: Se ajustó la variable `ai.service.base-url` al protocolo correcto para desarrollo local sin SSL.

## Cómo probarlo (Testing)

**Para la Sesión (Frontend):**
1. Hacer Login y copiar el JWT.
2. Lanzar `GET /api/auth/me` con el Header `Authorization: Bearer <token>`.
3. Validar que devuelve `200 OK` con los datos del médico, o `401 Unauthorized` si se altera el token.

**Para el Resumen de IA:**
1. Levantar el microservicio de Python (FastAPI) en el puerto `8000`.
2. Crear o actualizar una sesión clínica (POST/PATCH a `/api/patients/{id}/sessions`) rellenando los campos de notas clínicas.
3. Llamar al endpoint de Java que dispara el resumen.
4. Validar en la base de datos (o respuesta JSON) que el campo `summary` se ha rellenado correctamente con la estructura de viñetas y el texto generado por Python.