### PR TITLE
fix(db): resolver errores intermitentes de conexión con Supabase

### DIFF
--- a/apps/backend/src/main/resources/application.properties
+++ b/apps/backend/src/main/resources/application.properties
@@ -12,7 +12,7 @@ ai.service.base-url=http://localhost:8000
 # CONFIGURACION DE BASE DE DATOS
 # -------------------------------------------------------------------------
 # Usamos el puerto 6543 (Connection Pooler)
-spring.datasource.url=jdbc:postgresql://aws-1-us-east-1.pooler.supabase.com:6543/postgres
+spring.datasource.url=jdbc:postgresql://aws-1-us-east-1.pooler.supabase.com:6543/postgres?prepareThreshold=0
 spring.datasource.username=postgres.yrjrlrhznvpgvscnnkut
 spring.datasource.password=CieloSol1122
 spring.datasource.driver-class-name=org.postgresql.Driver
@@ -29,6 +29,10 @@ spring.jpa.show-sql=true
 spring.datasource.hikari.connection-test-query=SELECT 1
 spring.datasource.hikari.maximum-pool-size=10
 spring.datasource.hikari.minimum-idle=2
+# NUEVAS L\u00CDNEAS PARA EVITAR FALLOS INTERMITENTES:
+spring.datasource.hikari.max-lifetime=600000
+spring.datasource.hikari.keepalive-time=300000
+spring.datasource.hikari.validation-timeout=3000
 
 # -------------------------------------------------------------------------
 # CORS


### PR DESCRIPTION
- Añadido prepareThreshold=0 a la URL JDBC para evitar conflictos con PgBouncer en modo transaccional.
- Configurados max-lifetime y keepalive-time en HikariCP para renovar conexiones antes de que el servidor las cierre por inactividad.
- Esto soluciona las caídas intermitentes al hacer peticiones seguidas desde el Frontend."