### PR TITLE
Resúmenes de IA (Históricos)

### DIFF
--- a/apps/backend/src/main/java/com/example/authbackend/controller/HistoryChangeController.java
+++ b/apps/backend/src/main/java/com/example/authbackend/controller/HistoryChangeController.java
@@ -1,0 +1,25 @@
+package com.example.authbackend.controller;
+
+import com.example.authbackend.dto.HistoryChangeDTO;
+import com.example.authbackend.service.HistoryChangeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/patients")
+@RequiredArgsConstructor
+public class HistoryChangeController {
+    private final HistoryChangeService historyChangeService;
+
+    @GetMapping("/{patientId}/sessions/{sessionId}/historyChange")
+    public ResponseEntity<List<HistoryChangeDTO>> getPatientSessions(
+            @PathVariable Long patientId,
+            @PathVariable Long sessionId) {
+        return ResponseEntity.ok(historyChangeService.getHistoryChanges(sessionId));
+    }
+
+
+}

--- a/apps/backend/src/main/java/com/example/authbackend/controller/SessionController.java
+++ b/apps/backend/src/main/java/com/example/authbackend/controller/SessionController.java
@@ -2,7 +2,10 @@ package com.example.authbackend.controller;
 
 import com.example.authbackend.dto.ClinicalSessionDTO;
 import com.example.authbackend.dto.ClinicalSessionUpdateDTO;
+import com.example.authbackend.dto.ClinicalSummaryDTO;
+import com.example.authbackend.model.ClinicalSummary;
 import com.example.authbackend.service.ClinicalSessionService;
+import com.example.authbackend.service.ClinicalSummaryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,6 +20,7 @@ import java.util.List;
 public class SessionController {
 
     private final ClinicalSessionService sessionService;
+    private final ClinicalSummaryService clinicalSummaryService;
 
     /**
      * Endpoint para obtener el historial clínico completo de un paciente.
@@ -62,5 +66,22 @@ public class SessionController {
         ClinicalSessionDTO updatedSession = sessionService.generateAndSaveSummary(patientId, sessionId);
 
         return ResponseEntity.ok(updatedSession);
+    }
+
+    /**
+     * Endpoint para generar un resumen HISTÓRICO de varias sesiones entre dos fechas.
+     */
+    @PostMapping("/{patientId}/summaries/historical")
+    public ResponseEntity<ClinicalSummaryDTO> generateHistoricalSummary(
+            @PathVariable Long patientId,
+            @Valid @RequestBody com.example.authbackend.dto.ClinicalSummaryRequestDTO requestDTO) {
+
+        ClinicalSummaryDTO summary = clinicalSummaryService.generateHistoricalSummary(
+                patientId,
+                requestDTO.getDateFrom(),
+                requestDTO.getDateUntil()
+        );
+
+        return ResponseEntity.ok(summary);
     }
 }

--- a/apps/backend/src/main/java/com/example/authbackend/dto/ClinicalSessionDTO.java
+++ b/apps/backend/src/main/java/com/example/authbackend/dto/ClinicalSessionDTO.java
@@ -25,6 +25,7 @@ public class ClinicalSessionDTO {
     private String sessionType; // Ej: Individual presencial
     private String frequency; // Semanal, mensual..
     private Integer duration; // En minutos
+    private String status;
 
     // --- Narrativa Clínica ---
     private String observations;

--- a/apps/backend/src/main/java/com/example/authbackend/dto/ClinicalSessionUpdateDTO.java
+++ b/apps/backend/src/main/java/com/example/authbackend/dto/ClinicalSessionUpdateDTO.java
@@ -12,6 +12,7 @@ public class ClinicalSessionUpdateDTO {
     private String sessionType;
     private String frequency;
     private Integer duration;
+    private String status;
 
     // Campos clínicos (para rellenar durante o después de la sesión)
     private String observations;

--- a/apps/backend/src/main/java/com/example/authbackend/dto/ClinicalSummaryDTO.java
+++ b/apps/backend/src/main/java/com/example/authbackend/dto/ClinicalSummaryDTO.java
@@ -1,0 +1,18 @@
+package com.example.authbackend.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+@Data
+@Builder
+public class ClinicalSummaryDTO {
+    private Long id;
+    private String content;
+    private LocalDate dateFrom;
+    private LocalDate dateUntil;
+    private OffsetDateTime generatedAt;
+    private Long patientId;
+}

--- a/apps/backend/src/main/java/com/example/authbackend/dto/ClinicalSummaryRequestDTO.java
+++ b/apps/backend/src/main/java/com/example/authbackend/dto/ClinicalSummaryRequestDTO.java
@@ -1,0 +1,17 @@
+package com.example.authbackend.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class ClinicalSummaryRequestDTO {
+    @NotNull(message = "La fecha de inicio es obligatoria")
+    private LocalDate dateFrom;
+
+    @NotNull(message = "La fecha de fin es obligatoria")
+    private LocalDate dateUntil;
+}

--- a/apps/backend/src/main/java/com/example/authbackend/dto/HistoryChangeDTO.java
+++ b/apps/backend/src/main/java/com/example/authbackend/dto/HistoryChangeDTO.java
@@ -1,0 +1,19 @@
+package com.example.authbackend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.OffsetDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HistoryChangeDTO {
+
+    private OffsetDateTime changeDate;
+    private String previousContent;
+    private String newContent;
+
+}

--- a/apps/backend/src/main/java/com/example/authbackend/model/ClinicalSession.java
+++ b/apps/backend/src/main/java/com/example/authbackend/model/ClinicalSession.java
@@ -32,6 +32,10 @@ public class ClinicalSession {
 
     private Integer duration; // En minutos
 
+    //@Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    private String status;
+
     // --- CAMPOS DE TEXTO LARGO (Narrativa Clínica) ---
     // Usamos columnDefinition = "TEXT" para que Hibernate sepa que no es un VARCHAR(255)
 
@@ -62,6 +66,7 @@ public class ClinicalSession {
     @JoinColumn(name = "patient_id", nullable = false)
     @ToString.Exclude
     private Patient patient;
+
     @OneToMany(mappedBy = "session", fetch = FetchType.LAZY)
     private List<HistoryChange> historyChanges;
 

--- a/apps/backend/src/main/java/com/example/authbackend/repository/ClinicalSessionRepository.java
+++ b/apps/backend/src/main/java/com/example/authbackend/repository/ClinicalSessionRepository.java
@@ -29,4 +29,10 @@ public interface ClinicalSessionRepository extends JpaRepository<ClinicalSession
     // Busca las próximas 5 sesiones de este profesional, desde 'ahora' hacia el futuro, ordenadas por fecha más cercana.
     List<ClinicalSession> findTop5ByPatientProfessionalIdAndSessionDateTimeGreaterThanEqualOrderBySessionDateTimeAsc(
             Long professionalId, OffsetDateTime now);
+
+    List<ClinicalSession> findByPatientIdAndSessionDateTimeBetweenOrderBySessionDateTimeAsc(
+            Long patientId,
+            java.time.OffsetDateTime start,
+            java.time.OffsetDateTime end
+    );
 }

--- a/apps/backend/src/main/java/com/example/authbackend/repository/ClinicalSummaryRepository.java
+++ b/apps/backend/src/main/java/com/example/authbackend/repository/ClinicalSummaryRepository.java
@@ -1,0 +1,12 @@
+package com.example.authbackend.repository;
+
+import com.example.authbackend.model.ClinicalSummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ClinicalSummaryRepository extends JpaRepository<ClinicalSummary, Long> {
+    List<ClinicalSummary> findByPatientIdOrderByGeneratedAtDesc(Long patientId);
+}

--- a/apps/backend/src/main/java/com/example/authbackend/repository/HistoryChangeRepository.java
+++ b/apps/backend/src/main/java/com/example/authbackend/repository/HistoryChangeRepository.java
@@ -1,0 +1,19 @@
+package com.example.authbackend.repository;
+
+
+import com.example.authbackend.model.HistoryChange;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface HistoryChangeRepository extends JpaRepository<HistoryChange, Long> {
+
+    @Query("SELECT hc FROM HistoryChange hc WHERE hc.session.id = :sessionId " )
+    List<HistoryChange> findBySessionId(
+            @Param("sessionId") Long sessionId);
+
+
+}

--- a/apps/backend/src/main/java/com/example/authbackend/service/ClinicalSessionService.java
+++ b/apps/backend/src/main/java/com/example/authbackend/service/ClinicalSessionService.java
@@ -3,10 +3,12 @@ package com.example.authbackend.service;
 import com.example.authbackend.dto.ClinicalSessionDTO;
 import com.example.authbackend.dto.ClinicalSessionUpdateDTO;
 import com.example.authbackend.model.ClinicalSession;
+import com.example.authbackend.model.HistoryChange;
 import com.example.authbackend.model.LogCriticality;
 import com.example.authbackend.model.Patient;
 import com.example.authbackend.model.Professional;
 import com.example.authbackend.repository.ClinicalSessionRepository;
+import com.example.authbackend.repository.HistoryChangeRepository;
 import com.example.authbackend.repository.PatientRepository;
 import com.example.authbackend.repository.ProfessionalRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,7 @@ public class ClinicalSessionService {
     private final PatientRepository patientRepository;
     private final ProfessionalRepository professionalRepository;
     private final AiIntegrationService aiIntegrationService;
+    private final HistoryChangeRepository historyChangeRepository;
     private final LogService logService;
 
     /**
@@ -133,12 +136,17 @@ public class ClinicalSessionService {
         if (!session.getPatient().getId().equals(patientId)) {
             throw new RuntimeException("La sesión no pertenece al paciente indicado en la URL.");
         }
+
         // Calculamos la fecha y duración (si el DTO trae una nueva la usamos, si no, usamos la vieja)
         OffsetDateTime newStart = dto.getSessionDateTime() != null ? dto.getSessionDateTime() : session.getSessionDateTime();
         Integer newDuration = dto.getDuration() != null ? dto.getDuration() : session.getDuration();
 
         // Comprobamos que no se solapen sesiones
         validateNoOverlappingSessions(pro.getId(), newStart, newDuration, sessionId);
+
+        // Histórico de cambios:
+        // Guardamos el contenido previo.
+        String previousContent = buildNarrative(session);
 
         // Actualizamos solo los campos que no sean nulos
         if (dto.getSessionDateTime() != null) session.setSessionDateTime(dto.getSessionDateTime());
@@ -151,6 +159,8 @@ public class ClinicalSessionService {
         if (dto.getClinicalEvolution() != null) session.setClinicalEvolution(dto.getClinicalEvolution());
         if (dto.getTherapeuticGoals() != null) session.setTherapeuticGoals(dto.getTherapeuticGoals());
         if (dto.getDiagnosticNotes() != null) session.setDiagnosticNotes(dto.getDiagnosticNotes());
+        if (dto.getStatus() != null) session.setStatus(dto.getStatus());
+        session.setUpdatedAt(OffsetDateTime.now());
 
         ClinicalSession updatedSession = sessionRepository.save(session);
 
@@ -159,6 +169,23 @@ public class ClinicalSessionService {
                 "Modificación de sesión clínica ID: " + sessionId + " del paciente ID: " + patientId,
                 pro
         );
+
+        // HC: Guardamos el contenido nuevo
+        String newContent = buildNarrative(updatedSession);
+
+        // HC: Si cambió algo → registramos auditoría
+        if (!previousContent.equals(newContent)) {
+
+            HistoryChange history = HistoryChange.builder()
+                    .previousContent(previousContent)
+                    .newContent(newContent)
+                    .session(updatedSession)
+                    .changeDate(OffsetDateTime.now())
+                    .build();
+
+            historyChangeRepository.save(history);
+        }
+
         return convertToDTO(updatedSession);
     }
 
@@ -245,6 +272,30 @@ public class ClinicalSessionService {
                 .createdAt(session.getCreatedAt())
                 .updatedAt(session.getUpdatedAt())
                 .summary(session.getSummary())
+                .status(session.getStatus())
                 .build();
+    }
+
+    // Metodo helper para unificar el contenido clinico
+    private String buildNarrative(ClinicalSession session) {
+        return """
+                Status: %s
+                Observations: %s
+                Hypothesis: %s
+                Interventions: %s
+                Clinical Evolution: %s
+                Therapeutic Goals: %s
+                Diagnostic Notes: %s
+                Summary: %s
+                """.formatted(
+                    session.getStatus(),
+                    session.getObservations(),
+                    session.getHypothesis(),
+                    session.getInterventions(),
+                    session.getClinicalEvolution(),
+                    session.getTherapeuticGoals(),
+                    session.getDiagnosticNotes(),
+                    session.getSummary()
+                );
     }
 }

--- a/apps/backend/src/main/java/com/example/authbackend/service/ClinicalSummaryService.java
+++ b/apps/backend/src/main/java/com/example/authbackend/service/ClinicalSummaryService.java
@@ -1,0 +1,100 @@
+package com.example.authbackend.service;
+
+import com.example.authbackend.dto.ClinicalSummaryDTO;
+import com.example.authbackend.model.ClinicalSession;
+import com.example.authbackend.model.ClinicalSummary;
+import com.example.authbackend.model.LogCriticality;
+import com.example.authbackend.model.Patient;
+import com.example.authbackend.model.Professional;
+import com.example.authbackend.repository.ClinicalSessionRepository;
+import com.example.authbackend.repository.ClinicalSummaryRepository;
+import com.example.authbackend.repository.PatientRepository;
+import com.example.authbackend.repository.ProfessionalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ClinicalSummaryService {
+
+    private final ClinicalSummaryRepository summaryRepository;
+    private final ClinicalSessionRepository sessionRepository;
+    private final PatientRepository patientRepository;
+    private final ProfessionalRepository professionalRepository;
+    private final AiIntegrationService aiIntegrationService;
+    private final LogService logService;
+
+    private Professional getAuthenticatedProfessional() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        return professionalRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("Profesional no encontrado"));
+    }
+
+    @Transactional
+    public ClinicalSummaryDTO generateHistoricalSummary(Long patientId, LocalDate dateFrom, LocalDate dateUntil) {
+        Professional pro = getAuthenticatedProfessional();
+
+        Patient patient = patientRepository.findById(patientId)
+                .orElseThrow(() -> new RuntimeException("Paciente no encontrado"));
+
+        if (!patient.getProfessional().getId().equals(pro.getId())) {
+            throw new RuntimeException("Acceso denegado.");
+        }
+
+        // Convertimos los LocalDate a OffsetDateTime para buscar en la BD
+        OffsetDateTime start = dateFrom.atStartOfDay().atOffset(ZoneOffset.UTC);
+        OffsetDateTime end = dateUntil.plusDays(1).atStartOfDay().atOffset(ZoneOffset.UTC);
+
+        // Buscamos todas las sesiones en ese rango
+        List<ClinicalSession> sessions = sessionRepository
+                .findByPatientIdAndSessionDateTimeBetweenOrderBySessionDateTimeAsc(patientId, start, end);
+
+        if (sessions.isEmpty()) {
+            throw new RuntimeException("No hay sesiones en este rango de fechas para resumir.");
+        }
+
+        // Juntamos todas las notas de todas las sesiones
+        StringBuilder combinedNotes = new StringBuilder();
+        for (ClinicalSession session : sessions) {
+            combinedNotes.append("Fecha sesión: ").append(session.getSessionDateTime().toLocalDate()).append(". ");
+            if (session.getObservations() != null) combinedNotes.append("Observaciones: ").append(session.getObservations()).append(". ");
+            if (session.getClinicalEvolution() != null) combinedNotes.append("Evolución: ").append(session.getClinicalEvolution()).append(". ");
+            combinedNotes.append("\n");
+        }
+
+        // Llamamos al servicio de IA (Python)
+        String generatedSummary = aiIntegrationService.getSessionSummary(pro.getId(), combinedNotes.toString());
+
+        ClinicalSummary summary = ClinicalSummary.builder()
+                .content(generatedSummary)
+                .dateFrom(dateFrom)
+                .dateUntil(dateUntil)
+                .generatedAt(OffsetDateTime.now())
+                .patient(patient)
+                .build();
+
+        ClinicalSummary savedSummary = summaryRepository.save(summary);
+
+        logService.recordLog(
+                LogCriticality.LOW,
+                "Resumen histórico generado para paciente ID: " + patientId + " desde " + dateFrom + " hasta " + dateUntil,
+                pro
+        );
+
+        return ClinicalSummaryDTO.builder()
+                .id(savedSummary.getId())
+                .content(savedSummary.getContent())
+                .dateFrom(savedSummary.getDateFrom())
+                .dateUntil(savedSummary.getDateUntil())
+                .generatedAt(savedSummary.getGeneratedAt())
+                .patientId(savedSummary.getPatient().getId())
+                .build();
+    }
+}

--- a/apps/backend/src/main/java/com/example/authbackend/service/HistoryChangeService.java
+++ b/apps/backend/src/main/java/com/example/authbackend/service/HistoryChangeService.java
@@ -1,0 +1,34 @@
+package com.example.authbackend.service;
+
+import com.example.authbackend.dto.HistoryChangeDTO;
+import com.example.authbackend.model.HistoryChange;
+import com.example.authbackend.repository.HistoryChangeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+public class HistoryChangeService {
+
+    private final HistoryChangeRepository historyChangeRepository;
+
+    public List<HistoryChangeDTO> getHistoryChanges(Long sessionId) {
+
+        return historyChangeRepository.findBySessionId(sessionId)
+                .stream()
+                .map(this::convertToDTO)
+                .collect(Collectors.toList());
+    }
+
+    private HistoryChangeDTO convertToDTO(HistoryChange historyChange) {
+        return HistoryChangeDTO.builder()
+                .changeDate(historyChange.getChangeDate())
+                .newContent(historyChange.getNewContent())
+                .previousContent(historyChange.getPreviousContent())
+                .build();
+    }
+}


### PR DESCRIPTION
* **Nuevo Flujo de IA:** Añadido `ClinicalSummaryService` que busca todas las sesiones de un paciente entre dos fechas, concatena sus notas y se las envía al microservicio de Python de golpe.
* **Persistencia:** Los resúmenes históricos se guardan en su propia tabla `clinical_summaries`.
* **Nuevo Endpoint:** `POST /api/patients/{patientId}/summaries/historical` que recibe un body con `dateFrom` y `dateUntil`.